### PR TITLE
Allow passing `env` to render tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ If header missed - line number will be used instead.
 
 ## API
 
-### module.exports(path, options, env, md)
+### module.exports(path, options, md, env)
 
 - __path__ - file or directory name
 - __options__ (not mandatory)
   - __header__ - Default `false`. Set `true` to use heaters for test names
   - __sep__ - array of allowed separators for samples, [ '.' ] by default
   - __assert__ - custom assertion package, `require('chai').assert` by default.
-- __env__ (not mandatory) - environment object to be passed through to `markdown-it.render()`
 - __md__ - `markdown-it` instance to parse and compare samples
+- __env__ (not mandatory) - environment object to be passed through to `markdown-it.render()`
 
 ### module.exports.load(path, options, iterator)
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ If header missed - line number will be used instead.
 
 ## API
 
-### module.exports(path, options, md)
+### module.exports(path, options, env, md)
 
 - __path__ - file or directory name
 - __options__ (not mandatory)
   - __header__ - Default `false`. Set `true` to use heaters for test names
   - __sep__ - array of allowed separators for samples, [ '.' ] by default
   - __assert__ - custom assertion package, `require('chai').assert` by default.
+- __env__ (not mandatory) - environment object to be passed through to `markdown-it.render()`
 - __md__ - `markdown-it` instance to parse and compare samples
 
 ### module.exports.load(path, options, iterator)

--- a/index.js
+++ b/index.js
@@ -168,16 +168,13 @@ function load(path, options, iterator) {
 }
 
 
-function generate(path, options, env, md) {
+function generate(path, options, md, env) {
   if (!md) {
-    if (!env) {
-      md = options;
-      options = {};
-    } else {
-      md = env;
-    }
-    env = {};
+    md = options;
+    options = {};
   }
+
+  env = env || {};
 
   options = _.assign({}, options);
   options.assert = options.assert || require('chai').assert;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var p       = require('path');
 
 var _       = require('lodash');
 var yaml    = require('js-yaml');
-var merge   = require('merge');
 
 
 function fixLF (str) {
@@ -191,7 +190,7 @@ function generate(path, options, env, md) {
     (data.meta.skip ? describe.skip : describe)(desc, function () {
       data.fixtures.forEach(function (fixture) {
         it(fixture.header && options.header ? fixture.header : 'line ' + (fixture.first.range[0] - 1), function () {
-          options.assert.strictEqual(md.render(fixture.first.text, merge(true, env)), fixture.second.text);
+          options.assert.strictEqual(md.render(fixture.first.text, _.clone(env)), fixture.second.text);
         });
       });
     });

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var p       = require('path');
 
 var _       = require('lodash');
 var yaml    = require('js-yaml');
+var merge   = require('merge');
 
 
 function fixLF (str) {
@@ -168,10 +169,15 @@ function load(path, options, iterator) {
 }
 
 
-function generate(path, options, md) {
+function generate(path, options, env, md) {
   if (!md) {
-    md = options;
-    options = {};
+    if (!env) {
+      md = options;
+      options = {};
+    } else {
+      md = env;
+    }
+    env = {};
   }
 
   options = _.assign({}, options);
@@ -185,7 +191,7 @@ function generate(path, options, md) {
     (data.meta.skip ? describe.skip : describe)(desc, function () {
       data.fixtures.forEach(function (fixture) {
         it(fixture.header && options.header ? fixture.header : 'line ' + (fixture.first.range[0] - 1), function () {
-          options.assert.strictEqual(md.render(fixture.first.text), fixture.second.text);
+          options.assert.strictEqual(md.render(fixture.first.text, merge(true, env)), fixture.second.text);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "lodash": "~ 2.4.1",
     "chai": "~ 1.10.0",
-    "js-yaml": "~ 3.2.4"
+    "js-yaml": "~ 3.2.4",
+    "merge": "~ 1.2.0"
   },
   "devDependencies": {
     "eslint": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "lodash": "~ 2.4.1",
     "chai": "~ 1.10.0",
-    "js-yaml": "~ 3.2.4",
-    "merge": "~ 1.2.0"
+    "js-yaml": "~ 3.2.4"
   },
   "devDependencies": {
     "eslint": "0.11.0",


### PR DESCRIPTION
This allows me to add tests for the suggested implementation on https://github.com/markdown-it/markdown-it-footnote/pull/7

As usual, happy to be sent back to the drawing board with better ideas :)
